### PR TITLE
New alert for https://github.com/mozilla-it/duo_openvpn

### DIFF
--- a/alerts/duo_fail_open.py
+++ b/alerts/duo_fail_open.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python
+
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+# Copyright (c) 2014 Mozilla Corporation
+#
+# Contributors:
+# kang@mozilla.com
+#
+# This script alerts when openvpn's duo security failed to contact the duo server and let the user in.
+# This is a very serious warning that must be acted upon as it means MFA failed and only one factor was validated (in
+# this case a VPN certificate)
+
+from lib.alerttask import AlertTask
+import pyes
+
+class AlertDuoFailOpen(AlertTask):
+    def main(self):
+        # look for events in last 15 mins
+        date_timedelta = dict(minutes=15)
+        # Configure filters using pyes
+        must = [
+            pyes.TermFilter('_type', 'event'),
+            pyes.TermFilter('_source.tags', 'openvpn,duosecurity'),
+            pyes.QueryFilter(pyes.MatchQuery('summary','DuoAPI contact failed','phrase')),
+            pyes.QueryFilter(pyes.MatchQuery('summary','DuoAPI contact failed','phrase')),
+        ]
+        self.filtersManual(date_timedelta, must=must)
+
+        # Search aggregations on field 'sourceipaddress', keep 50 samples of events at most
+        self.searchEventsAggreg('hostname', samplesLimit=1)
+        # alert when >= X matching events in an aggregation
+        # in this case, always
+        self.walkAggregations(threshold=1)
+
+    # Set alert properties
+    def onAggreg(self, aggreg):
+        # aggreg['count']: number of items in the aggregation, ex: number of failed login attempts
+        # aggreg['value']: value of the aggregation field, ex: toto@example.com
+        # aggreg['events']: list of events in the aggregation
+        category = 'bypass'
+        tags = ['openvpn', 'duosecurity']
+        severity = 'WARNING'
+
+        summary = ('DuoSecurity OpenVPN contact failed, fail open triggered on {0}'.aggreg['value']))
+
+        # Create the alert object based on these properties
+        return self.createAlertDict(summary, category, tags, aggreg['events'], severity)


### PR DESCRIPTION
Alerts when fDuoSecurity contact fails, which is means either authentication was refused, either granted based on a
single authentication factor ("fail open").

How does that look like? For example, the aggregation is based on one term only since it makes sense to always alert. But I'm not sure if that's the correct way to do that.

Also, I'm not 100% sure about the term and query filter.  I suppose using _source or directly the name works.. but I'm not sure at all :)

I based myself on https://github.com/jeffbryner/MozDef/blob/master/alerts/bruteforce_ssh_pyes.py 
Related bug https://bugzilla.mozilla.org/show_bug.cgi?id=971606