### PR TITLE
Support querying bugzilla for bugs (for example, incident/investigation ...

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "lib/mozdef_client"]
 	path = lib/mozdef_client
 	url = https://github.com/gdestuynder/mozdef_client
+[submodule "bot/modules/bugzilla"]
+	path = bot/modules/bugzilla
+	url = https://github.com/gdestuynder/simple_bugzilla

--- a/bot/modules/zilla.py
+++ b/bot/modules/zilla.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python
+# Inspired by https://github.com/ayust/kitnirc/blob/master/kitnirc/contrib/healthcheck.py
+#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+# Copyright (c) 2014 Mozilla Corporation
+#
+# Contributors:
+# kang@mozilla.com
+#
+
+import logging
+from kitnirc.client import Channel
+from kitnirc.modular import Module
+from kitnirc.user import User
+import threading
+import time
+import json
+import bugzilla
+
+# get a logger for the module
+# via the Python logging library.
+_log = logging.getLogger(__name__)
+
+
+# KitnIRC modules subclass kitnirc.modular.Module
+class Zilla(Module):
+    def __init__(self, *args, **kwargs):
+        super(Zilla, self).__init__(*args, **kwargs)
+        self._stop = False
+        self.thread = threading.Thread(target=self.loop, name='zilla')
+        self.thread.daemon = True
+
+        config = self.controller.config
+        try:
+            self.url = config.get("zilla", "url")
+            self.api_key = config.get("zilla", "api_key")
+            self.interval = config.getint("zilla", "interval")
+            self.channel = config.get('zilla', 'channel')
+        except AttributeError:
+            _log.warning("Couldn't load the Zilla module, check your configuration.")
+            self.url = "https://example.com"
+            self.api_key = "DEADBEEF"
+            self.interval = 9999999
+            self.channel = '#test'
+
+        self._bugzilla = bugzilla.Bugzilla(url=self.url+'rest/', api_key=self.api_key)
+
+        _log.info("zilla module initialized for {}, pooling every {} seconds.".format(self.url, self.interval))
+
+    def loop(self):
+        last = 0
+        while not self._stop:
+            now = time.time()
+            if ((now-last) > self.interval):
+                #Add all the actions you want to do with bugzilla here ;)
+                self.bugzilla_search()
+                last = now
+            time.sleep(1)
+
+    def bugzilla_search(self):
+            config = self.controller.config
+            try:
+                terms = json.loads(config.get('zilla', 'search_terms'))
+            except AttributeError:
+                _log.warning("zilla could not load search terms")
+                return
+            try:
+                res = self._bugzilla.search_bugs(terms)
+            except:
+                return
+            for bug in res['bugs']:
+                self.controller.client.msg(self.channel, "[zilla] NEW bug: {summary} {url}{bugid}".format(summary=bug['summary'],
+                    url=self.url, bugid=bug['id']))
+
+    def start(self, *args, **kwargs):
+        super(Zilla, self).start(*args, **kwargs)
+        self._stop = False
+        self.thread.start()
+
+    def stop(self, *args, **kwargs):
+        super(Zilla, self).stop(*args, **kwargs)
+        self._stop = True
+        self.thread.join()
+
+
+# Let KitnIRC know what module class it should be loading.
+module = Zilla


### PR DESCRIPTION
...bugs)

New options:
[zilla]
url = https://bugzilla.mozilla.org/
api_key = your api key (user preferences => api keys)
; how often to check, in seconds
interval = 120
; the channel to tell about the new bugs
channel = #test
; what bugs to search for?
search_terms = [{"product": "mozilla.org"}, {"component": "Security Operations: Incident"}, {"component": "Security
Operations: Investigation"}, {"status": "NEW"}]