### PR TITLE
Fixed Deprecated warning about `GeometryUtil's .merge()` in globe visualization

### DIFF
--- a/meteor/app/client/globe.js
+++ b/meteor/app/client/globe.js
@@ -208,7 +208,8 @@ if (Meteor.isClient) {
         points.forEach(function(element, index, array) {
           if (element !== undefined && element.geometry !== undefined) {
             var subgeo = new THREE.Geometry();
-            THREE.GeometryUtils.merge(subgeo, element);
+            element.updateMatrix();
+            subgeo.merge(element.geometry, element.matrix);
             var mymesh = new THREE.Mesh(subgeo, new THREE.MeshBasicMaterial({
                   color: 0xffffff,
                   vertexColors: THREE.FaceColors,


### PR DESCRIPTION
Fixes three.js deprecated warning for globe visualization 
`DEPRECATED: GeometryUtils's .merge() has been moved to Geometry. Use geometry.merge( geometry2, matrix, materialIndexOffset ) instead.`