### PR TITLE
Fixup and normalize input of Okta logs

### DIFF
--- a/cron/okta2mozdef.py
+++ b/cron/okta2mozdef.py
@@ -133,6 +133,8 @@ def main():
                 else:
                     logger.error('Okta event does not contain published date: {0}'.format(event))
             state.write_state_file()
+        else:
+            logger.error('Could not get Okta events HTTP error code {} reason {}'.format(r.status_code, r.reason))
     except Exception as e:
         logger.error("Unhandled exception, terminating: %r"%e)
 

--- a/cron/okta2mozdef.py
+++ b/cron/okta2mozdef.py
@@ -124,6 +124,20 @@ def main():
                             if 'action' in event.keys() and 'message' in event['action'].keys():
                                 mozdefEvent['summary'] = event['action']['message']
                             mozdefEvent['details'] = event
+                            # Actor parsing
+                            # While there are various objectTypes attributes, we just take any attribute that matches
+                            # in case Okta changes it's structure around a bit
+                            # This means the last instance of each attribute in all actors will be recorded in mozdef
+                            # while others will be discarded
+                            # Which ends up working out well in Okta's case.
+                            if 'actors' in event.keys():
+                                for actor in event['actors']:
+                                    if 'ipAddress' in actor.keys():
+                                        mozdefEvent['details']['sourceipaddress'] = actor['ipAddress']
+                                    if 'login' in actor.keys():
+                                        mozdefEvent['details']['username'] = actor['login']
+                                    if 'requestUri' in actor.keys():
+                                        mozdefEvent['details']['source_uri'] = actor['requestUri']
                             jbody=json.dumps(mozdefEvent)
                             res=es.index(index='events',doc_type='okta',doc=jbody)
                             logger.debug(res)

--- a/cron/okta2mozdef.py
+++ b/cron/okta2mozdef.py
@@ -66,19 +66,19 @@ def main():
         s.headers.update({'Accept': 'application/json'})
         s.headers.update({'Content-type': 'application/json'})
         s.headers.update({'Authorization':'SSWS {0}'.format(options.apikey)})
-        
+
         #capture the time we start running so next time we catch any events created while we run.
         lastrun=toUTC(datetime.now()).isoformat()
         #in case we don't archive files..only look at today and yesterday's files.
         yesterday=date.strftime(datetime.utcnow()-timedelta(days=1),'%Y/%m/%d')
         today = date.strftime(datetime.utcnow(),'%Y/%m/%d')
-        
+
         r = s.get('https://{0}/api/v1/events?startDate={1}&limit={2}'.format(
             options.oktadomain,
             toUTC(options.lastrun).strftime('%Y-%m-%dT%H:%M:%S.000Z'),
             options.recordlimit
         ))
-        
+
         if r.status_code == 200:
             oktaevents = json.loads(r.text)
             for event in oktaevents:
@@ -100,7 +100,7 @@ def main():
                             continue
                 else:
                     logger.error('Okta event does not contain published date: {0}'.format(event))
-            setConfig('lastrun',lastrun,options.configfile)                            
+            setConfig('lastrun',lastrun,options.configfile)
     except Exception as e:
         logger.error("Unhandled exception, terminating: %r"%e)
 
@@ -115,7 +115,7 @@ def initConfig():
     options.esservers=list(getConfig('esservers','http://localhost:9200',options.configfile).split(','))
     options.lastrun=toUTC(getConfig('lastrun',toUTC(datetime.now()-timedelta(hours=1)),options.configfile))
     options.recordlimit = getConfig('recordlimit', 10000, options.configfile)                    #max number of records to request
-    
+
 
 if __name__ == '__main__':
     parser=OptionParser()


### PR DESCRIPTION
See also: https://github.com/jeffbryner/MozDef/issues/312 for normalization

This removes the rewriting of the config file, fixup some nits (whitespaces) and normalize a few useful fields.

Only tested shortly on mozdefqa1 so far.

From my experience writing this, I would propose creating a new issue to normalize all plugins and inputs, as well as creating a mozdeflib for parsing/reading (and usage of mozdef_client for sending, or both) so that we always query the fields the same way/easier to upgrade if fields format change.

@ameihm0912 as well for review